### PR TITLE
In v1 request_lines(), call gpio_set_line_values on correct FD

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -420,7 +420,7 @@ impl Internal<ChipInfo> {
             if let Some(values) = values {
                 let mut data = raw::v1::GpioHandleData::from_values(lines.len(), &values);
 
-                unsafe_call!(raw::v1::gpio_set_line_values(fd, &mut data))?;
+                unsafe_call!(raw::v1::gpio_set_line_values(request.fd, &mut data))?;
             }
 
             request.fd


### PR DESCRIPTION
raw::v1::gpio_set_line_values was being called on the wrong FD in the v1 request_lines, causing an -EINVAL result from ioctl()