### PR TITLE
Fix spurious WouldBlock errors when reading GPIO events

### DIFF
--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -24,6 +24,7 @@ pub use gpiod_core::{
 };
 
 use tokio::{fs, fs::OpenOptions, io::unix::AsyncFd, task::spawn_blocking};
+use tokio::io::Ready;
 
 async fn asyncify<F, T>(f: F) -> Result<T>
 where
@@ -81,14 +82,22 @@ impl Lines<Input> {
 
         #[cfg(feature = "v2")]
         {
-            let _ = self.file.readable().await?;
-
-            let mut event = gpiod_core::RawEvent::default();
-            let len = self.file.get_ref().read(event.as_mut())?;
-
-            gpiod_core::check_size(len, &event)?;
-
-            event.as_event(self.info.index())
+            loop {
+                let mut guard = self.file.readable().await?;
+                let mut event = gpiod_core::RawEvent::default();
+                match self.file.get_ref().read(event.as_mut()) {
+                    Ok(len) => {
+                        gpiod_core::check_size(len, &event)?;
+                        return event.as_event(self.info.index());
+                    },
+                    Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                        guard.clear_ready_matching(Ready::READABLE);
+                    },
+                    Err(e) => {
+                        return Err(e.into());
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Wrap the non-blocking read in a loop that clears the cached readiness flag on WouldBlock, re-arming the async wakeup. Previously, a spurious epoll notification would propagate as an error instead of retrying the read.

This is the correct implementation for AsyncFd according to the documentation in tokio's io/async_fd.rs.